### PR TITLE
Use prepare instead so that you can install directly from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "rollup -c && cp -r ./src/entries ./dist/entries",
     "format": "prettier --write \"**/*.{js,json,md}\" \"*.{js,json,md}\"",
     "lint": "eslint .",
-    "prepublishOnly": "yarn build",
+    "prepare": "yarn build",
     "release": "standard-version && conventional-github-releaser -p angular"
   },
   "devDependencies": {
@@ -31,7 +31,8 @@
     "prettier": "^2.3.2",
     "rollup": "^2.56.3",
     "rollup-plugin-esbuild": "^4.5.0",
-    "standard-version": "^9.3.1"
+    "standard-version": "^9.3.1",
+    "yarn": "^1.22.11"
   },
   "license": "MIT",
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4089,6 +4089,11 @@ yargs@^16.0.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yarn@^1.22.11:
+  version "1.22.11"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.11.tgz#d0104043e7349046e0e2aec977c24be106925ed6"
+  integrity sha512-AWje4bzqO9RUn3sdnM5N8n4ZJ0BqCc/kqFJvpOI5/EVkINXui0yuvU7NDCEF//+WaxHuNay2uOHxA4+tq1P3cg==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"


### PR DESCRIPTION
If you use a `prepare` script instead of `prepublishOnly`, one can install a development version of this package directly with:

```bash
yarn add https://github.com/gregberge/error-overlay-webpack-plugin.git#branch
```

Technically, we want to depend on `yarn` because it's used in the package scripts. An alternative that would work fine is to change the `script` to `npm run build`.